### PR TITLE
Refactor to use constants for KeyUsage type

### DIFF
--- a/siga-common/src/main/java/ee/openeid/siga/common/model/KeyUsageType.java
+++ b/siga-common/src/main/java/ee/openeid/siga/common/model/KeyUsageType.java
@@ -1,0 +1,19 @@
+package ee.openeid.siga.common.model;
+
+/**
+ * KeyUsage type as defined in @see
+ * <a href="https://datatracker.ietf.org/doc/html/rfc5280">RFC 5280</a>.
+ */
+public class KeyUsageType
+{
+    public static final int DIGITAL_SIGNATURE  = 0;
+    public static final int NON_REPUDIATION    = 1;
+    public static final int CONTENT_COMMITMENT = NON_REPUDIATION;
+    public static final int KEY_ENCIPHERMENT   = 2;
+    public static final int DATA_ENCIPHERMENT  = 3;
+    public static final int KEY_AGREEMENT      = 4;
+    public static final int KEY_CERT_SIGN      = 5;
+    public static final int CRL_SIGN           = 6;
+    public static final int ENCIPHER_ONLY      = 7;
+    public static final int DECIPHER_ONLY      = 8;
+}

--- a/siga-common/src/main/java/ee/openeid/siga/common/util/CertificateUtil.java
+++ b/siga-common/src/main/java/ee/openeid/siga/common/util/CertificateUtil.java
@@ -2,6 +2,7 @@ package ee.openeid.siga.common.util;
 
 import ee.openeid.siga.common.exception.InvalidCertificateException;
 import ee.openeid.siga.common.exception.TechnicalException;
+import ee.openeid.siga.common.model.KeyUsageType;
 import eu.europa.esig.dss.utils.Utils;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
@@ -45,7 +46,7 @@ public class CertificateUtil {
         if (certificate.getKeyUsage() == null || certificate.getKeyUsage().length < 2) {
             return false;
         }
-        return certificate.getKeyUsage()[1];
+        return certificate.getKeyUsage()[KeyUsageType.NON_REPUDIATION];
     }
 
 


### PR DESCRIPTION
Magic numbers in array indexes are hard to read.

Signed-off-by: Elion Sõber <elion.sober@gmail.com>
